### PR TITLE
Reflect budgetkey-ng2-components changes (v0.1.0)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ gulp.task('default', function(done) {
   runSequence('clean', 'assets', done);
 });
 
-gulp.task('assets', ['assets:app', 'assets:vendor']);
+gulp.task('assets', ['assets:app', 'assets:vendor', 'styles:vendor']);
 
 gulp.task('assets:app', function() {
   return gulp.src([
@@ -25,6 +25,14 @@ gulp.task('assets:vendor', function() {
     './node_modules/budgetkey-ng2-components/assets/**/*'
   ], {
     base: './node_modules/budgetkey-ng2-components'
+  }).pipe(gulp.dest('./dist'));
+});
+
+gulp.task('styles:vendor', function() {
+  return gulp.src([
+    './node_modules/budgetkey-ng2-components/lib/styles/**/*'
+  ], {
+    base: './node_modules/budgetkey-ng2-components/lib/styles/'
   }).pipe(gulp.dest('./dist'));
 });
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <title>מפתח התקציב - חיפוש</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" type="text/css" href="budgetkey-ng2-components.css">
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@angular/platform-browser-dynamic": "~2.2.0",
     "@angular/router": "~3.2.0",
     "angular-in-memory-web-api": "~0.1.15",
-    "budgetkey-ng2-components": "~0.0.1",
+    "budgetkey-ng2-components": "^0.1.0",
     "core-js": "^2.4.1",
     "lodash": "^4.17.2",
     "reflect-metadata": "^0.1.8",


### PR DESCRIPTION
In `budgetkey-ng2-components@0.1.0` all stylesheets were extracted to external file. Therefore all applications should  now explicitly use them.